### PR TITLE
Handle rotation, fix alignment, update example

### DIFF
--- a/crates/bevy_text/src/draw.rs
+++ b/crates/bevy_text/src/draw.rs
@@ -77,12 +77,13 @@ impl<'a> Drawable for DrawableText<'a> {
                 flip_y: false,
             };
 
-            let scale_transform = Mat4::from_scale(Vec3::splat(1. / self.scale_factor));
             let transform = Mat4::from_rotation_translation(
                 self.global_transform.rotation,
                 self.global_transform.translation,
-            ) * scale_transform
-                * Mat4::from_translation(self.alignment_offset + tv.position.extend(0.));
+            ) * Mat4::from_scale(self.global_transform.scale / self.scale_factor)
+                * Mat4::from_translation(
+                    self.alignment_offset * self.scale_factor + tv.position.extend(0.),
+                );
 
             let transform_buffer = context.get_uniform_buffer(&transform).unwrap();
             let sprite_buffer = context.get_uniform_buffer(&sprite).unwrap();

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -93,13 +93,13 @@ pub fn draw_text2d_system(
 
         if let Some(text_glyphs) = text_pipeline.get_glyphs(&entity) {
             let alignment_offset = match text.alignment.vertical {
-                VerticalAlign::Top => Vec3::ZERO,
+                VerticalAlign::Top => Vec3::new(0.0, -height, 0.0),
                 VerticalAlign::Center => Vec3::new(0.0, -height * 0.5, 0.0),
-                VerticalAlign::Bottom => Vec3::new(0.0, -height, 0.0),
+                VerticalAlign::Bottom => Vec3::ZERO,
             } + match text.alignment.horizontal {
-                HorizontalAlign::Left => Vec3::new(-width, 0.0, 0.0),
+                HorizontalAlign::Left => Vec3::ZERO,
                 HorizontalAlign::Center => Vec3::new(-width * 0.5, 0.0, 0.0),
-                HorizontalAlign::Right => Vec3::ZERO,
+                HorizontalAlign::Right => Vec3::new(-width, 0.0, 0.0),
             };
 
             let mut drawable_text = DrawableText {
@@ -110,7 +110,7 @@ pub fn draw_text2d_system(
                 text_glyphs: &text_glyphs.glyphs,
                 font_quad_vertex_layout: &font_quad_vertex_layout,
                 sections: &text.sections,
-                alignment_offset: alignment_offset * scale_factor,
+                alignment_offset,
             };
 
             drawable_text.draw(&mut draw, &mut context).unwrap();

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -175,7 +175,7 @@ pub fn draw_text_system(
                 text_glyphs: &text_glyphs.glyphs,
                 font_quad_vertex_layout: &vertex_buffer_layout,
                 sections: &text.sections,
-                alignment_offset: (node.size / -2.0).extend(0.0) * (scale_factor as f32),
+                alignment_offset: (node.size / -2.0).extend(0.0),
             };
 
             drawable_text.draw(&mut draw, &mut context).unwrap();

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -8,33 +8,65 @@ fn main() {
         .run();
 }
 
+struct AnimateTranslation;
+struct AnimateRotation;
+struct AnimateScale;
+
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    let font = asset_server.load("fonts/FiraSans-Bold.ttf");
+    let text_style = TextStyle {
+        font,
+        font_size: 60.0,
+        color: Color::WHITE,
+    };
+    let text_alignment = TextAlignment {
+        vertical: VerticalAlign::Center,
+        horizontal: HorizontalAlign::Center,
+    };
     // 2d camera
     commands.spawn_bundle(OrthographicCameraBundle::new_2d());
-    commands.spawn_bundle(Text2dBundle {
-        text: Text::with_section(
-            "This text is in the 2D scene.",
-            TextStyle {
-                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                font_size: 60.0,
-                color: Color::WHITE,
-            },
-            TextAlignment {
-                vertical: VerticalAlign::Center,
-                horizontal: HorizontalAlign::Center,
-            },
-        ),
-        ..Default::default()
-    });
+    // Demonstrate changing translation
+    commands
+        .spawn_bundle(Text2dBundle {
+            text: Text::with_section("translation", text_style.clone(), text_alignment),
+            ..Default::default()
+        })
+        .insert(AnimateTranslation);
+    // Demonstrate changing rotation
+    commands
+        .spawn_bundle(Text2dBundle {
+            text: Text::with_section("rotation", text_style.clone(), text_alignment),
+            ..Default::default()
+        })
+        .insert(AnimateRotation);
+    // Demonstrate changing scale
+    commands
+        .spawn_bundle(Text2dBundle {
+            text: Text::with_section("scale", text_style, text_alignment),
+            ..Default::default()
+        })
+        .insert(AnimateScale);
 }
 
-fn animate(time: Res<Time>, mut query: Query<&mut Transform, With<Text>>) {
-    // `Transform.translation` will determine the location of the text.
-    // `Transform.scale` (though you can set the size of the text via
-    // `Text.style.font_size`)
-    for mut transform in query.iter_mut() {
-        transform.translation.x = 100.0 * time.seconds_since_startup().sin() as f32;
+fn animate(
+    time: Res<Time>,
+    mut queries: QuerySet<(
+        Query<&mut Transform, WithBundle<(Text, AnimateTranslation)>>,
+        Query<&mut Transform, WithBundle<(Text, AnimateRotation)>>,
+        Query<&mut Transform, WithBundle<(Text, AnimateScale)>>,
+    )>,
+) {
+    for mut transform in queries.q0_mut().iter_mut() {
+        transform.translation.x = 100.0 * time.seconds_since_startup().sin() as f32 - 400.0;
         transform.translation.y = 100.0 * time.seconds_since_startup().cos() as f32;
+    }
+    for mut transform in queries.q1_mut().iter_mut() {
         transform.rotation = Quat::from_rotation_z(time.seconds_since_startup().cos() as f32);
+    }
+    // Consider changing font-size instead of scaling the transform. Scaling a Text2D will scale the
+    // rendered quad, resulting in a pixellated look.
+    for mut transform in queries.q2_mut().iter_mut() {
+        transform.translation = Vec3::new(400.0, 0.0, 0.0);
+        transform.scale = Vec3::splat((time.seconds_since_startup().sin() as f32 + 1.1) * 2.0);
     }
 }


### PR DESCRIPTION
@nside Here is a pull request to merge into [your pull request](https://github.com/bevyengine/bevy/pull/2084)!

If you'd rather leave your changes standalone, then I'll close this PR and open a separate one later after yours is merged. (But if you do that, you should still incorporate the alignment offset fix I made!).

Changes in this PR:
- Fix the vertical and horizontal alignment _offset_ handling (the _offset_ for top/bottom and left/right alignments were reversed)
- Move `scale_factor` handling for alignment offsets entirely into `DrawableText::draw` so that the call sites don't need to know to do the calculation
- Handle scaling based off of `Transform.scale`
  - I chose the approach to scale the entire quad, resulting in pixellated text when you scale it up. This may be a desirable effect for retro 2D games. For "smooth scaling", change the font size instead.
- Updated the `text2d` example to demonstrate translation, rotation, and scale separately (combining all three was difficult to understand what was going on, plus it was making me motion-sick 😝)
  - I used a `QuerySet` to handle all the queries in a single system. Would it be simpler for the user to understand if we used three separate systems instead?


![text2d-trs](https://user-images.githubusercontent.com/5838512/117086331-80136e00-ad09-11eb-87f9-baa07578c55d.gif)
